### PR TITLE
[fix] VSにてComponentGame.cppのblock初期化の修正など

### DIFF
--- a/Game/Game/ComponentGame.cpp
+++ b/Game/Game/ComponentGame.cpp
@@ -321,6 +321,7 @@ void ComponentGame::placeBlock(const vector<Player*> players)
 			block = new BlockTrap(blockSize);
 			break;
 		case Player::DECOY:
+		default:
 			block = nullptr;
 			break;
 		}

--- a/Game/Game/Game.vcxproj
+++ b/Game/Game/Game.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="Block.cpp" />
     <ClCompile Include="BlockAir.cpp" />
     <ClCompile Include="BlockNormalWall.cpp" />
+    <ClCompile Include="BlockTrap.cpp" />
     <ClCompile Include="BlockUnbreakableWall.cpp" />
     <ClCompile Include="BlockWall.cpp" />
     <ClCompile Include="Character.cpp" />
@@ -57,6 +58,7 @@
     <ClInclude Include="Block.hpp" />
     <ClInclude Include="BlockAir.hpp" />
     <ClInclude Include="BlockNormalWall.hpp" />
+    <ClInclude Include="BlockTrap.hpp" />
     <ClInclude Include="BlockUnbreakableWall.hpp" />
     <ClInclude Include="BlockWall.hpp" />
     <ClInclude Include="Character.h" />

--- a/Game/Game/Game.vcxproj.filters
+++ b/Game/Game/Game.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClCompile Include="Animation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="BlockTrap.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Character.h">
@@ -216,6 +219,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ComponentTexture.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="BlockTrap.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
ComponentGame.cppにて
blockをswitch文で初期化を行っていた部分を１行修正．
また，BlockTrap.hpp，BlockTrap.cppをプロジェクトに追加
